### PR TITLE
Create react toast notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node-sass": "^4.14.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-hot-toast": "^2.0.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.2",
     "supertest": "^4.0.2",

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,5 +1,6 @@
 import React, { lazy, Suspense, FunctionComponent } from 'react';
 import { Route, Switch } from 'react-router-dom';
+import { Toaster } from 'react-hot-toast';
 import ErrorPage from './components/ErrorPage';
 import PrivateRoute from './components/Utils/PrivateRoute';
 import PublicOnlyRoute from './components/Utils/PublicOnlyRoute';
@@ -49,6 +50,7 @@ const App: FunctionComponent = () => {
             </Switch>
           </Suspense>
         </ErrorPage>
+        <Toaster />
       </main>
     </>
   );

--- a/src/App/components/FoldersList/FoldersList.tsx
+++ b/src/App/components/FoldersList/FoldersList.tsx
@@ -3,19 +3,19 @@ import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faCheckCircle,
-  faThumbsDown,
-  faThumbsUp,
   faFolderPlus,
   faShareSquare,
   faDownload,
   faEdit,
   faTrashAlt,
 } from '@fortawesome/free-solid-svg-icons';
+import toast from 'react-hot-toast';
 import Folder from '../Folder/Folder';
 import Input from '../Input/Input';
 import TextArea from '../TextArea';
 import Button from '../Button';
 import LazyLoader from '../Loaders/LazyLoader';
+import DeleteExpand from '../DeleteExpand';
 import GeneralContext from '../../contexts/GeneralContext';
 import showdownFolderGenerate from '../../utils/generateFolder';
 import {
@@ -55,6 +55,8 @@ const FoldersList: FunctionComponent = () => {
   const handleDeleteExpand = () => {
     setDeleteClicked(!deleteClicked);
   };
+
+  const deleteSuccess = () => toast.success('Folder Deleted!');
 
   /* --------------------- */
 
@@ -165,25 +167,6 @@ const FoldersList: FunctionComponent = () => {
     );
   };
 
-  const renderDeleteExpand = (): JSX.Element => {
-    return (
-      <div>
-        <p>Are You Sure You'd Like to Delete this Folder?</p>
-        <Button
-          onClickCallback={() => {
-            handleDeleteFolder();
-            handleDeleteExpand();
-          }}
-        >
-          Yes <FontAwesomeIcon icon={faThumbsUp} />
-        </Button>
-        <Button onClickCallback={() => handleDeleteExpand()}>
-          No <FontAwesomeIcon icon={faThumbsDown} />
-        </Button>
-      </div>
-    );
-  };
-
   return (
     <>
       <section className={styles['folders-list']}>
@@ -270,7 +253,17 @@ const FoldersList: FunctionComponent = () => {
         </div>
         <div>
           {editClicked && renderEditExpand()}
-          {deleteClicked && renderDeleteExpand()}
+          {deleteClicked && (
+            <DeleteExpand
+              message={"Are You Sure You'd Like to Delete this Folder?"}
+              yesCallback={() => {
+                handleDeleteFolder();
+                handleDeleteExpand();
+                deleteSuccess();
+              }}
+              noCallback={() => handleDeleteExpand()}
+            />
+          )}
         </div>
       </section>
     </>

--- a/src/App/components/FoldersList/FoldersList.tsx
+++ b/src/App/components/FoldersList/FoldersList.tsx
@@ -11,6 +11,7 @@ import {
   faEdit,
   faTrashAlt,
 } from '@fortawesome/free-solid-svg-icons';
+import { Toaster } from 'react-hot-toast';
 import Folder from '../Folder/Folder';
 import Input from '../Input/Input';
 import TextArea from '../TextArea';
@@ -46,8 +47,7 @@ const FoldersList: FunctionComponent = () => {
 
   const [editClicked, setEditClicked] = useState(false);
   const [deleteClicked, setDeleteClicked] = useState(false);
-  const { copySuccess, textArea, setCopySuccess, copyCodeToClipboard } =
-    useClipboard();
+  const { copySuccess, textArea, copyCodeToClipboard } = useClipboard();
 
   const handleEditExpand = () => {
     setEditClicked(!editClicked);
@@ -213,14 +213,12 @@ const FoldersList: FunctionComponent = () => {
           {currentClickedFolder.value && (
             <div>
               <div className={styles['export-team']}>
-                {copySuccess && (
-                  <div className={styles['copied']}>Copied to Clipboard!!</div>
-                )}
+                <Toaster />
                 <div>
                   <Button
                     onClickCallback={() => {
                       copyCodeToClipboard();
-                      setTimeout(() => setCopySuccess(false), 3000);
+                      copySuccess();
                     }}
                   >
                     Copy Text

--- a/src/App/components/FoldersList/FoldersList.tsx
+++ b/src/App/components/FoldersList/FoldersList.tsx
@@ -11,7 +11,6 @@ import {
   faEdit,
   faTrashAlt,
 } from '@fortawesome/free-solid-svg-icons';
-import { Toaster } from 'react-hot-toast';
 import Folder from '../Folder/Folder';
 import Input from '../Input/Input';
 import TextArea from '../TextArea';
@@ -213,7 +212,6 @@ const FoldersList: FunctionComponent = () => {
           {currentClickedFolder.value && (
             <div>
               <div className={styles['export-team']}>
-                <Toaster />
                 <div>
                   <Button
                     onClickCallback={() => {

--- a/src/App/components/PokemonSetForm/ExpandedSet/ExpandedSet.tsx
+++ b/src/App/components/PokemonSetForm/ExpandedSet/ExpandedSet.tsx
@@ -13,7 +13,6 @@ import {
   faDownload,
   faTrashAlt,
 } from '@fortawesome/free-solid-svg-icons';
-import { Toaster } from 'react-hot-toast';
 import Button from '../../Button';
 import Input from '../../Input';
 import TextArea from '../../TextArea';
@@ -254,7 +253,6 @@ const ExpandedSet: FunctionComponent<ExpandedSetProps> = ({
       </form>
 
       <div className={styles['export-pokemon']}>
-        <Toaster />
         <div>
           <Button
             onClickCallback={() => {

--- a/src/App/components/PokemonSetForm/ExpandedSet/ExpandedSet.tsx
+++ b/src/App/components/PokemonSetForm/ExpandedSet/ExpandedSet.tsx
@@ -13,6 +13,7 @@ import {
   faDownload,
   faTrashAlt,
 } from '@fortawesome/free-solid-svg-icons';
+import { Toaster } from 'react-hot-toast';
 import Button from '../../Button';
 import Input from '../../Input';
 import TextArea from '../../TextArea';
@@ -148,14 +149,10 @@ const ExpandedSet: FunctionComponent<ExpandedSetProps> = ({
     handleDeleteSet,
   } = useContext(GeneralContext);
 
-  const { copySuccess, textArea, setCopySuccess, copyCodeToClipboard } =
-    useClipboard();
+  const { copySuccess, textArea, copyCodeToClipboard } = useClipboard();
 
   return (
     <div className={styles['pokemon']}>
-      {/* <Button onClickCallback={() => handleSetToggle()}>
-        Compress Set <FontAwesomeIcon icon={faCompressArrowsAlt} />
-      </Button> */}
       {!isPublic && (
         <form>
           <div className={styles['pokemon-import']}>
@@ -257,14 +254,12 @@ const ExpandedSet: FunctionComponent<ExpandedSetProps> = ({
       </form>
 
       <div className={styles['export-pokemon']}>
-        {copySuccess && (
-          <div className={styles['copied']}>Copied to Clipboard!!</div>
-        )}
+        <Toaster />
         <div>
           <Button
             onClickCallback={() => {
               copyCodeToClipboard();
-              setTimeout(() => setCopySuccess(false), 3000);
+              copySuccess();
             }}
           >
             Copy Text

--- a/src/App/components/PokemonSetForm/ExpandedSet/ExpandedSet.tsx
+++ b/src/App/components/PokemonSetForm/ExpandedSet/ExpandedSet.tsx
@@ -13,6 +13,7 @@ import {
   faDownload,
   faTrashAlt,
 } from '@fortawesome/free-solid-svg-icons';
+import toast from 'react-hot-toast';
 import Button from '../../Button';
 import Input from '../../Input';
 import TextArea from '../../TextArea';
@@ -149,6 +150,8 @@ const ExpandedSet: FunctionComponent<ExpandedSetProps> = ({
   } = useContext(GeneralContext);
 
   const { copySuccess, textArea, copyCodeToClipboard } = useClipboard();
+
+  const deleteSuccess = () => toast.success('Set Deleted!');
 
   return (
     <div className={styles['pokemon']}>
@@ -309,6 +312,7 @@ const ExpandedSet: FunctionComponent<ExpandedSetProps> = ({
             yesCallback={() => {
               handleDeleteSet(set?.team_id || NaN, set?.id || NaN);
               setDeleteClicked(!deleteClicked);
+              deleteSuccess();
             }}
             noCallback={() => setDeleteClicked(!deleteClicked)}
           />

--- a/src/App/components/Team-Public-Share/Team-Public-Share.tsx
+++ b/src/App/components/Team-Public-Share/Team-Public-Share.tsx
@@ -5,6 +5,7 @@ import {
   faCompressArrowsAlt,
   faShareSquare,
 } from '@fortawesome/free-solid-svg-icons';
+import { Toaster } from 'react-hot-toast';
 import Input from '../Input/Input';
 import TextArea from '../TextArea';
 import Image from '../Image';
@@ -31,8 +32,7 @@ const TeamPublicShare: FunctionComponent<TeamPublicShareProps> = ({
   sets,
 }): JSX.Element => {
   const [teamExpandToggle, setTeamExpandToggle] = useState(true);
-  const { copySuccess, textArea, setCopySuccess, copyCodeToClipboard } =
-    useClipboard();
+  const { copySuccess, textArea, copyCodeToClipboard } = useClipboard();
 
   const handleTeamToggle = () => {
     setTeamExpandToggle(!teamExpandToggle);
@@ -99,14 +99,12 @@ const TeamPublicShare: FunctionComponent<TeamPublicShareProps> = ({
               />
             </form>
             <div className={styles['export-team']}>
-              {copySuccess && (
-                <div className={styles['copied']}>Copied to Clipboard!!</div>
-              )}
+              <Toaster />
               <div>
                 <Button
                   onClickCallback={() => {
                     copyCodeToClipboard();
-                    setTimeout(() => setCopySuccess(false), 3000);
+                    copySuccess();
                   }}
                 >
                   Copy Text

--- a/src/App/components/Team-Public-Share/Team-Public-Share.tsx
+++ b/src/App/components/Team-Public-Share/Team-Public-Share.tsx
@@ -5,7 +5,6 @@ import {
   faCompressArrowsAlt,
   faShareSquare,
 } from '@fortawesome/free-solid-svg-icons';
-import { Toaster } from 'react-hot-toast';
 import Input from '../Input/Input';
 import TextArea from '../TextArea';
 import Image from '../Image';
@@ -99,7 +98,6 @@ const TeamPublicShare: FunctionComponent<TeamPublicShareProps> = ({
               />
             </form>
             <div className={styles['export-team']}>
-              <Toaster />
               <div>
                 <Button
                   onClickCallback={() => {

--- a/src/App/components/Team/ExpandedTeam/ExpandedTeam.tsx
+++ b/src/App/components/Team/ExpandedTeam/ExpandedTeam.tsx
@@ -9,6 +9,7 @@ import {
   faTrashAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import classnames from 'classnames';
+import { Toaster } from 'react-hot-toast';
 import Button from '../../Button';
 import Input from '../../Input';
 import TextArea from '../../TextArea';
@@ -51,8 +52,7 @@ const ExpandedTeam: FunctionComponent<ExpandedTeamProps> = ({
   inputTeamName,
   setDesc,
 }) => {
-  const { copySuccess, textArea, setCopySuccess, copyCodeToClipboard } =
-    useClipboard();
+  const { copySuccess, textArea, copyCodeToClipboard } = useClipboard();
 
   const { handleUpdateTeam } = useContext(GeneralContext);
 
@@ -143,14 +143,12 @@ const ExpandedTeam: FunctionComponent<ExpandedTeamProps> = ({
             )}
           </form>
           <div className={styles['export-team']}>
-            {copySuccess && (
-              <div className={styles['copied']}>Copied to Clipboard!!</div>
-            )}
+            <Toaster />
             <div>
               <Button
                 onClickCallback={() => {
                   copyCodeToClipboard();
-                  setTimeout(() => setCopySuccess(false), 3000);
+                  copySuccess();
                 }}
               >
                 Copy Text

--- a/src/App/components/Team/ExpandedTeam/ExpandedTeam.tsx
+++ b/src/App/components/Team/ExpandedTeam/ExpandedTeam.tsx
@@ -9,6 +9,7 @@ import {
   faTrashAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import classnames from 'classnames';
+import toast from 'react-hot-toast';
 import Button from '../../Button';
 import Input from '../../Input';
 import TextArea from '../../TextArea';
@@ -54,6 +55,8 @@ const ExpandedTeam: FunctionComponent<ExpandedTeamProps> = ({
   const { copySuccess, textArea, copyCodeToClipboard } = useClipboard();
 
   const { handleUpdateTeam } = useContext(GeneralContext);
+
+  const deleteSuccess = () => toast.success('Team Deleted!');
 
   return (
     <section className={styles['team-section']} id={`${id}`}>
@@ -205,6 +208,7 @@ const ExpandedTeam: FunctionComponent<ExpandedTeamProps> = ({
                 handleDeleteExpand();
                 handleTeamToggle();
                 team.id && handleDeleteTeam(team.id);
+                deleteSuccess();
               }}
               noCallback={() => handleDeleteExpand()}
             />

--- a/src/App/components/Team/ExpandedTeam/ExpandedTeam.tsx
+++ b/src/App/components/Team/ExpandedTeam/ExpandedTeam.tsx
@@ -9,7 +9,6 @@ import {
   faTrashAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import classnames from 'classnames';
-import { Toaster } from 'react-hot-toast';
 import Button from '../../Button';
 import Input from '../../Input';
 import TextArea from '../../TextArea';
@@ -143,7 +142,6 @@ const ExpandedTeam: FunctionComponent<ExpandedTeamProps> = ({
             )}
           </form>
           <div className={styles['export-team']}>
-            <Toaster />
             <div>
               <Button
                 onClickCallback={() => {

--- a/src/App/components/Team/UnexpandedTeam/UnexpandedTeam.module.scss
+++ b/src/App/components/Team/UnexpandedTeam/UnexpandedTeam.module.scss
@@ -1,8 +1,10 @@
 @import '../../../../index.scss';
 
 .sprites-row {
-  display: grid;
-  grid-template-columns: repeat(6, auto);
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  flex-wrap: wrap;
   .tiny-icon {
     height: 35px;
   }

--- a/src/App/components/Team/UnexpandedTeam/UnexpandedTeam.module.scss
+++ b/src/App/components/Team/UnexpandedTeam/UnexpandedTeam.module.scss
@@ -1,9 +1,8 @@
 @import '../../../../index.scss';
 
 .sprites-row {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: repeat(6, auto);
   .tiny-icon {
     height: 35px;
   }

--- a/src/App/contexts/GeneralContext.tsx
+++ b/src/App/contexts/GeneralContext.tsx
@@ -7,6 +7,7 @@ import React, {
   Dispatch,
   SetStateAction,
 } from 'react';
+import toast from 'react-hot-toast';
 import apiService from '../services/apiService';
 import TokenService from '../services/token-service';
 import jwtDecode from 'jwt-decode';
@@ -318,6 +319,7 @@ export const GeneralProvider = ({ children }: ContextProps): JSX.Element => {
 
   const handlePostNewFolder = () => {
     let folder: PokemonFolder;
+    const folderSuccessToast = () => toast.success('Posted New Folder!!');
     apiService
       .postUserFolder(
         newFolderName.value,
@@ -326,6 +328,7 @@ export const GeneralProvider = ({ children }: ContextProps): JSX.Element => {
       .then((f) => {
         folder = f;
         setUserFolders([...userFolders, folder]);
+        folderSuccessToast();
       })
       .then(() => {
         if (newFolderImport.value) {
@@ -447,6 +450,11 @@ export const GeneralProvider = ({ children }: ContextProps): JSX.Element => {
           });
         }
       })
+      .catch((error) => {
+        const folderErrorToast = () =>
+          toast.error(`Posting New Folder Failed: ${error}`);
+        folderErrorToast();
+      })
       .then(() => {
         setFolderAddClicked(!folderAddClicked);
         setNewFolderName({ value: '', touched: false });
@@ -484,12 +492,22 @@ export const GeneralProvider = ({ children }: ContextProps): JSX.Element => {
       move_four: null,
     };
 
+    const setSuccessToast = () => toast.success('Posted New Pokemon Set!!');
+
     apiService
       .postUserSet(
         set_body,
         jwtDecode<MyToken>(TokenService.getAuthToken() || '').user_id
       )
-      .then((set) => setUserSets([...userSets, set]));
+      .then((set) => {
+        setSuccessToast();
+        setUserSets([...userSets, set]);
+      })
+      .catch((error) => {
+        const setErrorToast = () =>
+          toast.error(`Posting New Pokemon Set Failed: ${error}`);
+        setErrorToast();
+      });
   };
 
   const handlePostNewTeam = () => {
@@ -499,12 +517,15 @@ export const GeneralProvider = ({ children }: ContextProps): JSX.Element => {
       folder_id: Number(currentClickedFolder.id),
     };
 
+    const teamSuccessToast = () => toast.success('Posted New Team!!');
+
     apiService
       .postUserTeam(
         body,
         jwtDecode<MyToken>(TokenService.getAuthToken() || '').user_id
       )
       .then((team) => {
+        teamSuccessToast();
         setUserTeams([
           ...userTeams,
           {
@@ -578,6 +599,11 @@ export const GeneralProvider = ({ children }: ContextProps): JSX.Element => {
             setUserSets([...userSets, ...sets]);
           });
         }
+      })
+      .catch((error) => {
+        const teamErrorToast = () =>
+          toast.error(`Posting New Team Failed: ${error}`);
+        teamErrorToast();
       });
     setTeamAddClicked(!teamAddClicked);
     setNewTeamName({ value: '', touched: false });
@@ -590,11 +616,18 @@ export const GeneralProvider = ({ children }: ContextProps): JSX.Element => {
       TokenService.getAuthToken() || ''
     ).user_id;
 
-    apiService.patchUserFolder(
-      newFolderName.value,
-      currentClickedFolder.id,
-      userId
-    );
+    const folderSuccessToast = () => toast.success('Edited Folder!!');
+
+    apiService
+      .patchUserFolder(newFolderName.value, currentClickedFolder.id, userId)
+      .then(() => {
+        folderSuccessToast();
+      })
+      .catch((error) => {
+        const setErrorToast = () =>
+          toast.error(`Editing Folder Failed: ${error}`);
+        setErrorToast();
+      });
 
     const folder = { folder_name: newFolderName.value };
 
@@ -612,7 +645,17 @@ export const GeneralProvider = ({ children }: ContextProps): JSX.Element => {
     const userId = jwtDecode<MyToken>(
       TokenService.getAuthToken() || ''
     ).user_id;
-    apiService.patchUserTeam(body, userId);
+    const teamSuccessToast = () => toast.success('Edited Team!!');
+    apiService
+      .patchUserTeam(body, userId)
+      .then(() => {
+        teamSuccessToast();
+      })
+      .catch((error) => {
+        const setErrorToast = () =>
+          toast.error(`Editing Team Failed: ${error}`);
+        setErrorToast();
+      });
 
     const team = { team_name: teamname, description: desc };
 
@@ -683,7 +726,18 @@ export const GeneralProvider = ({ children }: ContextProps): JSX.Element => {
     const userId = jwtDecode<MyToken>(
       TokenService.getAuthToken() || ''
     ).user_id;
-    apiService.patchUserSet(body, userId);
+
+    const setSuccessToast = () => toast.success('Edited Pokemon Set!!');
+    apiService
+      .patchUserSet(body, userId)
+      .then(() => {
+        setSuccessToast();
+      })
+      .catch((error) => {
+        const setErrorToast = () =>
+          toast.error(`Editing Pokemon Set Failed: ${error}`);
+        setErrorToast();
+      });
 
     const set = {
       nickname,
@@ -726,6 +780,8 @@ export const GeneralProvider = ({ children }: ContextProps): JSX.Element => {
       TokenService.getAuthToken() || ''
     ).user_id;
 
+    const setSuccessToast = () => toast.success('Team Import Successful!!');
+
     const body = {
       id: id,
       nickname: parsed.nickname,
@@ -754,7 +810,16 @@ export const GeneralProvider = ({ children }: ContextProps): JSX.Element => {
       move_three: parsed.move_three,
       move_four: parsed.move_four,
     };
-    apiService.patchUserSet(body, userId);
+    apiService
+      .patchUserSet(body, userId)
+      .then(() => {
+        setSuccessToast();
+      })
+      .catch((error) => {
+        const setErrorToast = () =>
+          toast.error(`Pokemon Set Import Failed: ${error}`);
+        setErrorToast();
+      });
 
     const set = {
       nickname: parsed.nickname,

--- a/src/App/utils/customHooks/useClipboard.tsx
+++ b/src/App/utils/customHooks/useClipboard.tsx
@@ -1,14 +1,14 @@
-import { useState, useRef } from 'react';
+import { useRef } from 'react';
+import toast from 'react-hot-toast';
 
 interface ClipboardReturn {
-  copySuccess: boolean;
+  copySuccess: () => string;
   textArea: React.RefObject<HTMLTextAreaElement>;
-  setCopySuccess: React.Dispatch<React.SetStateAction<boolean>>;
   copyCodeToClipboard: () => void;
 }
 
 const useClipboard = (): ClipboardReturn => {
-  const [copySuccess, setCopySuccess] = useState(false);
+  const copySuccess = () => toast.success('Copied to Clipboard!!');
   const textArea = useRef<HTMLTextAreaElement>(null);
 
   const copyCodeToClipboard = () => {
@@ -16,14 +16,12 @@ const useClipboard = (): ClipboardReturn => {
       textArea.current.select();
       const text = textArea.current.defaultValue;
       navigator.clipboard.writeText(text);
-      setCopySuccess(true);
     }
   };
 
   return {
     copySuccess,
     textArea,
-    setCopySuccess,
     copyCodeToClipboard,
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6174,6 +6174,11 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
+goober@^2.0.35:
+  version "2.0.39"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.0.39.tgz#0a52bf78ee9562270669e7603f0250f014f37cb1"
+  integrity sha512-ryw0VaZaehKmnjL4ZEJaiUVQc+XFa5dXIAbf2QC3F+WVKRbzaSuJyq7w28bdlwqYctiZ0Ok5QL/Pap5M2pCHQg==
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
@@ -10364,6 +10369,13 @@ react-error-overlay@^6.0.9:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
+
+react-hot-toast@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.0.0.tgz#6e83b2937a20b040acb2d5fd08bcf32561b7832a"
+  integrity sha512-J0J2rcSvKetlziVquwESgk85pV9JB0Dz3RJIZcAEv7CWU2y2z8BQqxmZHZUxjPKIBGPqXAocZch4Kj4oUdX4+w==
+  dependencies:
+    goober "^2.0.35"
 
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"


### PR DESCRIPTION
- Implements React-Hot-Toast for API calls, delete (though this may need to move to the Context itself) and the useClipboard hook, handles successes and hopefully failures as well.
- Fixes a bug where if a team of more than 6 (which is possible given showdown's antics), it displays the sprite row as wrapped so it doesnt overflow.  It helps alleviate teams with 'long' pokemon that would otherwise overflow as well on smallest screens.