### PR TITLE
Fix Gender-Lock saving issue

### DIFF
--- a/src/App/components/PokemonSetForm/ExpandedSet/Intro/Intro.tsx
+++ b/src/App/components/PokemonSetForm/ExpandedSet/Intro/Intro.tsx
@@ -61,10 +61,16 @@ const Intro: FunctionComponent<IntroProps> = ({
       ];
     }
     if (legality.returnGenderStatus(species) === 'M') {
-      return [{ value: 'M', label: 'Male' }];
+      return [
+        { value: '', label: '------' },
+        { value: 'M', label: 'Male' },
+      ];
     }
     if (legality.returnGenderStatus(species) === 'F') {
-      return [{ value: 'F', label: 'Female' }];
+      return [
+        { value: '', label: '------' },
+        { value: 'F', label: 'Female' },
+      ];
     }
     if (legality.returnGenderStatus(species) === null) {
       return [{ value: '', label: 'No Gender' }];

--- a/src/App/utils/validations.ts
+++ b/src/App/utils/validations.ts
@@ -182,7 +182,8 @@ export const validateGender = (
   if (legality.returnGenderStatus(species.value)) {
     if (
       gender.value.toString().trim() !==
-      legality.returnGenderStatus(species.value)
+        legality.returnGenderStatus(species.value) &&
+      !!gender.value.toString()
     ) {
       return `This species is locked to a gender of '${legality.returnGenderStatus(
         species.value


### PR DESCRIPTION
fixes #170
Fixed legality by accepting blank genders and adding a null option for gender locked male and female pokemon so users can either ignore the gender or select the proper gender.